### PR TITLE
add service and stacktrace to error logs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,9 +9,9 @@ jobs:
       with:
         python-version: '3.9'
         architecture: x64
-    - run: pip install nox==2020.12.31
-    - run: pip install poetry==1.1.4
-    - run: pip install nox-poetry==0.8.4
+    - run: pip install nox==2021.6.12
+    - run: pip install poetry==1.1.7
+    - run: pip install nox-poetry==0.8.6
     - run: nox --sessions tests coverage
       env:
         CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -30,9 +30,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install poetry==1.1.4
-        pip install nox==2020.12.31
-        pip install nox-poetry==0.8.4
+        pip install poetry==1.1.7
+        pip install nox==2021.6.12
+        pip install nox-poetry==0.8.6
 
     - name: Build image and run tests with nox
       run: nox

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -32,9 +32,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install poetry==1.1.4
-        pip install nox==2020.12.31
-        pip install nox-poetry==0.8.4
+        pip install poetry==1.1.7
+        pip install nox==2021.6.12
+        pip install nox-poetry==0.8.6
 
     - name: Build image and run tests with nox
       run: nox

--- a/src/fdk_organization_bff/gunicorn_config.py
+++ b/src/fdk_organization_bff/gunicorn_config.py
@@ -40,6 +40,7 @@ class StackdriverJsonFormatter(jsonlogger.JsonFormatter, object):
         """Process log record to a json-format compatible with Stackdriver."""
         log_record["severity"] = log_record["levelname"]
         del log_record["levelname"]
+        log_record["serviceContext"] = {"service": "fdk-organization-bff"}
         return super(StackdriverJsonFormatter, self).process_log_record(log_record)
 
 

--- a/src/fdk_organization_bff/utils/mappers.py
+++ b/src/fdk_organization_bff/utils/mappers.py
@@ -1,5 +1,6 @@
 """Mapper module."""
 import logging
+import traceback
 from typing import Dict, List, Optional
 
 from fdk_organization_bff.classes import (
@@ -34,7 +35,9 @@ def map_catalog_quality_rating(
                 else None,
             )
         except BaseException:
-            logging.error("bad data from fdk-metadata-quality-service", assessment_data)
+            logging.error(
+                f"{traceback.format_exc()}: bad data from fdk-metadata-quality-service {assessment_data}"
+            )
     return None
 
 

--- a/src/fdk_organization_bff/utils/utils.py
+++ b/src/fdk_organization_bff/utils/utils.py
@@ -1,6 +1,7 @@
 """Util module."""
 import datetime
 import logging
+import traceback
 from typing import Dict, Optional
 from urllib.parse import quote_plus
 
@@ -50,7 +51,7 @@ def resource_is_new(resource: Dict) -> bool:
             seven_days_ago = datetime.date.today() - datetime.timedelta(days=7)
             return issued_date >= seven_days_ago
         except BaseException:
-            logging.error("failed to parse issued date")
+            logging.error(f"{traceback.format_exc()}: failed to parse issued date")
     return False
 
 


### PR DESCRIPTION
Feilmeldingene vil nå inkludere en stacktrace ie:
```
Traceback (most recent call last):
  File "/app/src/fdk_organization_bff/resources/org_catalogs.py", line 20, in get
    raise BaseException("Feilmelding fra exception")
BaseException: Feilmelding fra exception
: egendefinert melding
```

Som da vil resultere i at den vil propagere videre til `Error reporting` i GCP
ref:
https://cloud.google.com/error-reporting/docs/formatting-error-messages#json_representation
https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#ReportedErrorEvent