### PR TITLE
chore: deactivate fetch of mqa scores for large catalogs

### DIFF
--- a/src/fdk_organization_bff/service/adapter.py
+++ b/src/fdk_organization_bff/service/adapter.py
@@ -211,9 +211,12 @@ async def fetch_org_dataset_catalog_scores(
     """Fetch rating for organization's dataset catalog from fdk-metadata-quality-service."""
     url = f"{Config.metadata_uri()}/api/scores"
 
-    scores = await fetch_json_data_with_post(url, {"datasets": uris}, session)
-
-    if scores and isinstance(scores, Dict):
-        return scores
-    else:
+    if len(uris) > 500:
         return dict()
+    else:
+        scores = await fetch_json_data_with_post(url, {"datasets": uris}, session)
+
+        if scores and isinstance(scores, Dict):
+            return scores
+        else:
+            return dict()


### PR DESCRIPTION
Må sannsynligvis jobbe en del med hele mqa-løpet før vi kan fikse dette på en god måte, har oppretta dette for å ta tak i problemet senere: https://github.com/Informasjonsforvaltning/fdk-issue-tracker/issues/1059

Så på kort sikt bare deaktiverer vi